### PR TITLE
Python 3.x compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-from senteval import *

--- a/examples/bow.py
+++ b/examples/bow.py
@@ -2,8 +2,10 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
+
+from __future__ import absolute_import, division, unicode_literals
 
 import sys
 import numpy as np
@@ -14,23 +16,23 @@ from exutil import dotdict
 import data
 
 # Set PATHs
-PATH_TO_SENTEVAL = '../'
-PATH_TO_DATA = '../data/senteval_data/'
+PATH_TO_SENTEVAL = '../senteval'
+PATH_TO_DATA = '../data/senteval_data'
 PATH_TO_GLOVE = 'glove/glove.840B.300d.txt'
-                
+
 # import SentEval
 sys.path.insert(0, PATH_TO_SENTEVAL)
 import senteval
 
 
 """
-Note: 
+Note:
 
 The user has to implement two functions:
     1) "batcher" : transforms a batch of sentences into sentence embeddings.
         i) takes as input a "batch", and "params".
         ii) outputs a numpy array of sentence embeddings
-        iii) Your sentence encoder should be in "params" 
+        iii) Your sentence encoder should be in "params"
     2) "prepare" : sees the whole dataset, and can create a vocabulary
         i) outputs of "prepare" are stored in "params" that batcher will use.
 """
@@ -45,7 +47,7 @@ def prepare(params, samples):
 def batcher(params, batch):
     batch = [sent if sent!=[] else ['.'] for sent in batch]
     embeddings = []
-    
+
     for sent in batch:
         sentvec = []
         for word in sent:
@@ -65,19 +67,22 @@ params_senteval = {'task_path': PATH_TO_DATA, 'usepytorch': False, 'kfold':5}
 params_senteval = dotdict(params_senteval)
 
 # set gpu device
-torch.cuda.set_device(0)
+if torch.cuda.is_available():
+    torch.cuda.set_device(0)
 
 # Set up logger
 logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
 
 if __name__ == "__main__":
     se = senteval.SentEval(params_senteval, batcher, prepare)
-    transfer_tasks = ['MR', 'CR', 'MPQA', 'SUBJ', 'SST', 'TREC', 'MRPC', 'SICKEntailment', 'SICKRelatedness', 'STSBenchmark', 'STS14']
+    transfer_tasks = [
+        'MR', 'CR', 'MPQA', 'SUBJ', 'SST', 'TREC', 'MRPC', 'SICKEntailment', 'SICKRelatedness', 'STSBenchmark', 'STS14'
+    ]
     results = se.eval(transfer_tasks)
 
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+

--- a/examples/data.py
+++ b/examples/data.py
@@ -2,10 +2,13 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
+from __future__ import absolute_import, division, unicode_literals
+
 import time
+import io
 import numpy as np
 from random import randint
 import logging
@@ -20,7 +23,7 @@ def create_dictionary(sentences, threshold=0):
     for s in sentences:
         for word in s:
             words[word] = words.get(word, 0) + 1
-            
+
     if threshold > 0:
         newwords = {}
         for word in words:
@@ -37,7 +40,7 @@ def create_dictionary(sentences, threshold=0):
     for i, (w, _) in enumerate(sorted_words):
         id2word.append(w)
         word2id[w] = i
-    
+
     return id2word, word2id
 
 
@@ -45,12 +48,12 @@ def create_dictionary(sentences, threshold=0):
 def get_wordvec(path_to_vec, word2id):
     word_vec = {}
 
-    with open(path_to_vec) as f:
+    with io.open(path_to_vec, 'r', encoding='utf-8') as f:
         # if word2vec or fasttext file : skip first line "next(f)"
         for line in f:
             word, vec = line.split(' ', 1)
             if word in word2id:
                 word_vec[word] = np.fromstring(vec, sep=' ')
-                
-    logging.info('Found {0} words with word vectors, out of {1} words'.format(len(word_vec), len(word2id)))                
+
+    logging.info('Found {0} words with word vectors, out of {1} words'.format(len(word_vec), len(word2id)))
     return word_vec

--- a/examples/infersent.py
+++ b/examples/infersent.py
@@ -2,17 +2,20 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
+
+from __future__ import absolute_import, division, unicode_literals
 
 import sys, os
 import torch
 from exutil import dotdict
 import logging
 
+
 # Set PATHs
 GLOVE_PATH = 'glove/glove.840B.300d.txt'
-PATH_SENTEVAL = '../'
+PATH_SENTEVAL = '../senteval'
 PATH_TO_DATA = '../data/senteval_data/'
 MODEL_PATH = 'infersent.allnli.pickle'
 
@@ -24,16 +27,16 @@ import senteval
 
 
 def prepare(params, samples):
-    params.infersent.build_vocab([' '.join(s) for s in samples], tokenize=False) 
+    params.infersent.build_vocab([' '.join(s) for s in samples], tokenize=False)
 
 def batcher(params, batch):
     # batch contains list of words
     sentences = [' '.join(s) for s in batch]
     embeddings = params.infersent.encode(sentences, bsize=params.batch_size, tokenize=False)
-    return embeddings 
-    
+    return embeddings
 
-    
+
+
 """
 Evaluation of trained model on Transfer Tasks (SentEval)
 """

--- a/examples/models.py
+++ b/examples/models.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree. 
 #
 
+from __future__ import absolute_import, division, unicode_literals
+
 import numpy as np
 import time
 

--- a/examples/skipthought.py
+++ b/examples/skipthought.py
@@ -2,8 +2,10 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
+
+from __future__ import absolute_import, division, unicode_literals
 
 """
 Example of file to compare skipthought vectors with our InferSent model
@@ -11,7 +13,7 @@ Example of file to compare skipthought vectors with our InferSent model
 import logging
 
 import sys
-reload(sys)  
+reload(sys)
 sys.setdefaultencoding('utf8')
 
 import torch
@@ -19,7 +21,7 @@ from exutil import dotdict
 
 
 # Set PATHs
-PATH_TO_SENTEVAL = '../'
+PATH_TO_SENTEVAL = '../senteval'
 PATH_TO_DATA = '../data/senteval_data/'
 PATH_TO_SKIPTHOUGHT = ''
 assert PATH_TO_SKIPTHOUGHT != '', 'Download skipthought and set correct PATH'
@@ -58,9 +60,9 @@ if __name__ == "__main__":
     se = senteval.SentEval(params_senteval, batcher, prepare)
     se.eval(['MR', 'CR', 'SUBJ', 'MPQA', 'SST', 'TREC', 'SICKRelatedness', 'SICKEntailment', 'MRPC', 'STS14', 'ImageAnnotation'])
 
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+

--- a/senteval/__init__.py
+++ b/senteval/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .senteval import SentEval

--- a/senteval/binary.py
+++ b/senteval/binary.py
@@ -2,19 +2,21 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
 Binary classifier and corresponding datasets : MR, CR, SUBJ, MPQA
 '''
+from __future__ import absolute_import, division, unicode_literals
 
-import codecs
+import io
 import os
 import numpy as np
 import logging
 
 from tools.validation import InnerKFoldClassifier
+
 
 class BinaryClassifierEval(object):
     def __init__(self, pos, neg, seed=1111):
@@ -29,8 +31,9 @@ class BinaryClassifierEval(object):
         # Those output will be further used by "batcher".
 
     def loadFile(self, fpath):
-        with codecs.open(fpath, 'rb', 'latin-1') as f:
-            return [line.encode('utf-8').split() for line in f.read().splitlines()]
+        with io.open(fpath, 'r', encoding='latin-1') as f:
+            file = [line.split() for line in f.read().splitlines()]
+            return file
 
     def run(self, params, batcher):
         enc_input = []
@@ -53,12 +56,14 @@ class BinaryClassifierEval(object):
         logging.debug('Dev acc : {0} Test acc : {1}\n'.format(devacc, testacc))
         return {'devacc': devacc, 'acc': testacc, 'ndev': self.n_samples, 'ntest': self.n_samples}
 
+
 class CREval(BinaryClassifierEval):
     def __init__(self, task_path, seed=1111):
         logging.debug('***** Transfer task : CR *****\n\n')
         pos = self.loadFile(os.path.join(task_path, 'custrev.pos'))
         neg = self.loadFile(os.path.join(task_path, 'custrev.neg'))
         super(self.__class__, self).__init__(pos, neg, seed)
+
 
 class MREval(BinaryClassifierEval):
     def __init__(self, task_path, seed=1111):
@@ -67,12 +72,14 @@ class MREval(BinaryClassifierEval):
         neg = self.loadFile(os.path.join(task_path, 'rt-polarity.neg'))
         super(self.__class__, self).__init__(pos, neg, seed)
 
+
 class SUBJEval(BinaryClassifierEval):
     def __init__(self, task_path, seed=1111):
         logging.debug('***** Transfer task : SUBJ *****\n\n')
         obj = self.loadFile(os.path.join(task_path, 'subj.objective'))
         subj = self.loadFile(os.path.join(task_path, 'subj.subjective'))
         super(self.__class__, self).__init__(obj, subj, seed)
+
 
 class MPQAEval(BinaryClassifierEval):
     def __init__(self, task_path, seed=1111):

--- a/senteval/mrpc.py
+++ b/senteval/mrpc.py
@@ -2,22 +2,24 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
 MRPC : Microsoft Research Paraphrase (detection) Corpus
 '''
+from __future__ import absolute_import, division, unicode_literals
 
 import os
 import logging
 import numpy as np
+import io
 
 from tools.validation import KFoldClassifier
 
 from sklearn.metrics import f1_score
 
-        
+
 class MRPCEval(object):
     def __init__(self, task_path, seed=1111):
         logging.info('***** Transfer task : MRPC *****\n\n')
@@ -25,31 +27,30 @@ class MRPCEval(object):
         train = self.loadFile(os.path.join(task_path, 'msr_paraphrase_train.txt'))
         test = self.loadFile(os.path.join(task_path, 'msr_paraphrase_test.txt'))
         self.mrpc_data = {'train':train, 'test':test}
-        
+
     def do_prepare(self, params, prepare):
         # TODO : Should we separate samples in "train, test"?
         samples = self.mrpc_data['train']['X_A'] + self.mrpc_data['train']['X_B'] + \
                   self.mrpc_data['test']['X_A'] + self.mrpc_data['test']['X_B']
         return prepare(params, samples)
 
-    def loadFile(self, fpath):       
+    def loadFile(self, fpath):
         mrpc_data = {'X_A':[], 'X_B':[], 'y':[]}
-        with open(fpath, 'rb') as f:
+        with io.open(fpath, 'r', encoding='utf-8') as f:
             for line in f:
                 text = line.strip().split('\t')
                 mrpc_data['X_A'].append(text[3].split())
                 mrpc_data['X_B'].append(text[4].split())
                 mrpc_data['y'].append(text[0])
-                
+
         mrpc_data['X_A'] = mrpc_data['X_A'][1:]
         mrpc_data['X_B'] = mrpc_data['X_B'][1:]
         mrpc_data['y'] = [int(s) for s in mrpc_data['y'][1:]]
         return mrpc_data
-        
 
     def run(self, params, batcher):
         mrpc_embed = {'train':{}, 'test':{}}
-                      
+
         for key in self.mrpc_data:
             logging.info('Computing embedding for {0}'.format(key))
             # Sort to reduce padding
@@ -59,11 +60,11 @@ class MRPCEval(object):
                                        self.mrpc_data[key]['X_B'],
                                        self.mrpc_data[key]['y']),
                                    key=lambda z:(len(z[0]), len(z[1]), z[2]))
-            
+
             text_data['A'] = [x for (x,y,z) in sorted_corpus]
             text_data['B'] = [y for (x,y,z) in sorted_corpus]
             text_data['y'] = [z for (x,y,z) in sorted_corpus]
-            
+
             for txt_type in ['A', 'B']:
                 mrpc_embed[key][txt_type] = []
                 for ii in range(0, len(text_data['y']), params.batch_size):
@@ -73,19 +74,19 @@ class MRPCEval(object):
                 mrpc_embed[key][txt_type] = np.vstack(mrpc_embed[key][txt_type])
             mrpc_embed[key]['y'] = np.array(text_data['y'])
             logging.info('Computed {0} embeddings'.format(key))
-        
+
         # Train
         trainA = mrpc_embed['train']['A']
         trainB = mrpc_embed['train']['B']
         trainF = np.c_[np.abs(trainA - trainB), trainA * trainB]
         trainY = mrpc_embed['train']['y']
-        
+
         # Test
         testA = mrpc_embed['test']['A']
         testB = mrpc_embed['test']['B']
         testF = np.c_[np.abs(testA - testB), testA * testB]
         testY = mrpc_embed['test']['y']
-        
+
         config_classifier = {'nclasses':2, 'seed':self.seed, 'usepytorch':params.usepytorch,\
                             'classifier':params.classifier, 'nhid': params.nhid, 'kfold': params.kfold}
         clf = KFoldClassifier(train={'X':trainF, 'y':trainY}, test={'X':testF, 'y':testY},\

--- a/senteval/rank.py
+++ b/senteval/rank.py
@@ -2,44 +2,49 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
 Image-Caption Retrieval with COCO dataset
 '''
+from __future__ import absolute_import, division, unicode_literals
 
 import os
 import copy
 import logging
-import cPickle
 import numpy as np
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
 from tools.ranking import ImageSentenceRankingPytorch
+
 
 class ImageCaptionRetrievalEval(object):
     def __init__(self, task_path, seed=1111):
         logging.debug('***** Transfer task : Image Caption Retrieval *****\n\n')
-        
+
         # Get captions and image features
         self.seed = seed
         train, dev, test = self.loadFile(task_path)
         self.coco_data = {'train':train, 'dev':dev, 'test':test}
-        
+
     def do_prepare(self, params, prepare):
         samples = self.coco_data['train']['sent'] + self.coco_data['dev']['sent'] + \
                   self.coco_data['test']['sent']
         prepare(params, samples)
-        
-        
+
     def loadFile(self, fpath):
         coco = {}
 
         for split in ['train', 'valid', 'test']:
             list_sent = []
-            list_img_feat = [] 
+            list_img_feat = []
             with open(os.path.join(fpath, split + '.pkl')) as f:
-                 cocodata = cPickle.load(f)
+                 cocodata = pickle.load(f)
             for imgkey in range(len(cocodata['features'])):
                 assert len(cocodata['image_to_caption_ids'][imgkey]) >= 5, cocodata['image_to_caption_ids'][imgkey]
                 for captionkey in cocodata['image_to_caption_ids'][imgkey][0:5]:
@@ -49,20 +54,19 @@ class ImageCaptionRetrievalEval(object):
             assert len(list_sent) == len(list_img_feat) and len(list_sent)%5 == 0
             coco[split] = {'sent':list_sent, 'imgfeat':np.array(list_img_feat).astype('float32')}
         return coco['train'], coco['valid'], coco['test']
-    
 
     def run(self, params, batcher):
         coco_embed = {'train':{'sentfeat':[], 'imgfeat':[]}, \
                      'dev':{'sentfeat':[], 'imgfeat':[]}, \
                      'test':{'sentfeat':[], 'imgfeat':[]}}
-                      
-        for key in self.coco_data:  
+
+        for key in self.coco_data:
             logging.info('Computing embedding for {0}'.format(key))
             # Sort to reduce padding
             self.coco_data[key]['sent'] = np.array(self.coco_data[key]['sent'])
             self.coco_data[key]['sent'], idx_sort = np.sort(self.coco_data[key]['sent']), np.argsort(self.coco_data[key]['sent'])
             idx_unsort = np.argsort(idx_sort)
-            
+
             coco_embed[key]['X'] = []
             for ii in range(0, len(self.coco_data[key]['sent']), params.batch_size):
                 batch = self.coco_data[key]['sent'][ii:ii + params.batch_size]
@@ -75,12 +79,12 @@ class ImageCaptionRetrievalEval(object):
         config_classifier = {'seed':self.seed, 'projdim':1000, 'margin':0.2}
         clf = ImageSentenceRankingPytorch(train=coco_embed['train'], valid=coco_embed['dev'], \
                               test=coco_embed['test'], config=config_classifier)
-        
+
         bestdevscore, r1_i2t, r5_i2t, r10_i2t, medr_i2t, r1_t2i, r5_t2i, r10_t2i, medr_t2i = clf.run()
-        
+
         logging.debug("\nTest scores | Image to text: {0}, {1}, {2}, {3}".format(r1_i2t, r5_i2t, r10_i2t, medr_i2t))
         logging.debug("Test scores | Text to image: {0}, {1}, {2}, {3}\n".format(r1_t2i, r5_t2i, r10_t2i, medr_t2i))
-            
+
         return {'devacc': bestdevscore, 'acc': [(r1_i2t, r5_i2t, r10_i2t, medr_i2t), (r1_t2i, r5_t2i, r10_t2i, medr_t2i)], 'ndev': len(coco_embed['dev']['sentfeat']), 'ntest': len(coco_embed['test']['sentfeat'])}
 
-    
+

--- a/senteval/senteval.py
+++ b/senteval/senteval.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
@@ -10,6 +10,8 @@
 Generic sentence evaluation scripts wrapper
 
 '''
+from __future__ import absolute_import, division, unicode_literals
+
 from binary import CREval, MREval, MPQAEval, SUBJEval
 from snli import SNLIEval
 from trec import TRECEval
@@ -36,18 +38,17 @@ class SentEval(object):
             self.prepare = prepare
         else:
             self.prepare = lambda x,y: None
-        
+
         # sanity check
         assert params.classifier in ['LogReg', 'MLP']
         if params.classifier == 'MLP':
             assert params.nhid>0, 'When using an MLP, you need to set params.nhid>0'
         if not params.usepytorch and params.classifier == 'MLP':
-            assert False, 'No MLP implemented in scikit-learn'        
-        
+            assert False, 'No MLP implemented in scikit-learn'
+
         self.list_tasks = ['CR', 'MR', 'MPQA', 'SUBJ', 'SST', 'TREC', 'MRPC', 'SICKRelatedness',\
                       'SICKEntailment', 'STSBenchmark', 'SNLI', 'ImageCaptionRetrieval',\
-                          'STS12', 'STS13', 'STS14', 'STS15', 'STS16']        
-        
+                          'STS12', 'STS13', 'STS14', 'STS15', 'STS16']
 
     def eval(self, name):
         ''' evaluate on evaluation [name], either takes string or list of strings '''
@@ -86,9 +87,9 @@ class SentEval(object):
 
         self.params.current_task = name
         self.evaluation.do_prepare(self.params, self.prepare)
-        
+
         self.results = self.evaluation.run(self.params, self.batcher)
-        
+
         return self.results
 
 

--- a/senteval/sick.py
+++ b/senteval/sick.py
@@ -2,14 +2,16 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
 SICK Relatedness and Entailment
 '''
+from __future__ import absolute_import, division, unicode_literals
 
 import os
+import io
 import logging
 import numpy as np
 
@@ -19,6 +21,7 @@ from scipy.stats import pearsonr, spearmanr
 from tools.relatedness import RelatednessPytorch
 from tools.validation import SplitClassifier
 
+
 class SICKRelatednessEval(object):
     def __init__(self, task_path, seed=1111):
         logging.debug('***** Transfer task : SICK-Relatedness*****\n\n')
@@ -27,17 +30,17 @@ class SICKRelatednessEval(object):
         dev = self.loadFile(os.path.join(task_path, 'SICK_trial.txt'))
         test = self.loadFile(os.path.join(task_path, 'SICK_test_annotated.txt'))
         self.sick_data = {'train':train, 'dev':dev, 'test':test}
-        
+
     def do_prepare(self, params, prepare):
         samples = self.sick_data['train']['X_A'] + self.sick_data['train']['X_B'] + \
                   self.sick_data['dev']['X_A'] + self.sick_data['dev']['X_B'] + \
                   self.sick_data['test']['X_A'] + self.sick_data['test']['X_B']
         return prepare(params, samples)
-        
+
     def loadFile(self, fpath):
         skipFirstLine = True
         sick_data = {'X_A':[], 'X_B':[], 'y':[]}
-        with open(fpath, 'rb') as f:
+        with io.open(fpath, 'r', encoding='utf-8') as f:
             for line in f:
                 if skipFirstLine:
                     skipFirstLine = False
@@ -46,26 +49,25 @@ class SICKRelatednessEval(object):
                     sick_data['X_A'].append(text[1].split())
                     sick_data['X_B'].append(text[2].split())
                     sick_data['y'].append(text[3])
-        
+
         sick_data['y'] = [float(s) for s in sick_data['y']]
         return sick_data
-    
-    
+
     def run(self, params, batcher):
         sick_embed = {'train':{}, 'dev':{}, 'test':{}}
-                      
-        for key in self.sick_data:  
+
+        for key in self.sick_data:
             logging.info('Computing embedding for {0}'.format(key))
             # Sort to reduce padding
             sorted_corpus = sorted(zip(self.sick_data[key]['X_A'],
                                        self.sick_data[key]['X_B'],
                                        self.sick_data[key]['y']),
                                    key=lambda z:(len(z[0]), len(z[1]), z[2]))
-            
+
             self.sick_data[key]['X_A'] = [x for (x,y,z) in sorted_corpus]
             self.sick_data[key]['X_B'] = [y for (x,y,z) in sorted_corpus]
             self.sick_data[key]['y'] = [z for (x,y,z) in sorted_corpus]
-           
+
             for txt_type in ['X_A', 'X_B']:
                 sick_embed[key][txt_type] = []
                 for ii in range(0, len(self.sick_data[key]['y']), params.batch_size):
@@ -75,34 +77,34 @@ class SICKRelatednessEval(object):
                 sick_embed[key][txt_type] = np.vstack(sick_embed[key][txt_type])
             sick_embed[key]['y'] = np.array(self.sick_data[key]['y'])
             logging.info('Computed {0} embeddings'.format(key))
-            
+
         # Train
         trainA = sick_embed['train']['X_A']
         trainB = sick_embed['train']['X_B']
         trainF = np.c_[np.abs(trainA - trainB), trainA * trainB]
         trainY = self.encode_labels(self.sick_data['train']['y'])
-        
+
         # Dev
         devA = sick_embed['dev']['X_A']
         devB = sick_embed['dev']['X_B']
         devF = np.c_[np.abs(devA - devB), devA * devB]
         devY = self.encode_labels(self.sick_data['dev']['y'])
-        
+
         # Test
         testA = sick_embed['test']['X_A']
         testB = sick_embed['test']['X_B']
         testF = np.c_[np.abs(testA - testB), testA * testB]
         testY = self.encode_labels(self.sick_data['test']['y'])
-        
+
         config_classifier = {'seed':self.seed, 'nclasses':5}
         clf = RelatednessPytorch(train={'X':trainF, 'y':trainY},
                                     valid={'X':devF, 'y':devY},
                                     test={'X':testF, 'y':testY},
                                     devscores=self.sick_data['dev']['y'],
                                     config=config_classifier)
-        
+
         devpr, yhat = clf.run()
-        
+
         pr = pearsonr(yhat, self.sick_data['test']['y'])[0]
         sr = spearmanr(yhat, self.sick_data['test']['y'])[0]
         se = mean_squared_error(yhat, self.sick_data['test']['y'])
@@ -111,7 +113,7 @@ class SICKRelatednessEval(object):
         #import pdb
         #pdb.set_trace()
         return {'devpearson':devpr, 'pearson': pr, 'spearman':sr, 'mse':se, 'yhat':yhat, 'ndev': len(devA), 'ntest': len(testA)}
-       
+
     def encode_labels(self, labels, nclass=5):
         """
         Label encoding from Tree LSTM paper (Tai, Socher, Manning)
@@ -124,7 +126,7 @@ class SICKRelatednessEval(object):
                 if i+1 == np.floor(y):
                     Y[j,i] = np.floor(y) - y + 1
         return Y
-                
+
 
 class SICKEntailmentEval(SICKRelatednessEval):
     def __init__(self, task_path, seed=1111):
@@ -134,12 +136,12 @@ class SICKEntailmentEval(SICKRelatednessEval):
         dev = self.loadFile(os.path.join(task_path, 'SICK_trial.txt'))
         test = self.loadFile(os.path.join(task_path, 'SICK_test_annotated.txt'))
         self.sick_data = {'train':train, 'dev':dev, 'test':test}
-        
+
     def loadFile(self, fpath):
         label2id = {'CONTRADICTION':0, 'NEUTRAL':1, 'ENTAILMENT':2}
         skipFirstLine = True
         sick_data = {'X_A':[], 'X_B':[], 'y':[]}
-        with open(fpath, 'rb') as f:
+        with io.open(fpath, 'r', encoding='utf-8') as f:
             for line in f:
                 if skipFirstLine:
                     skipFirstLine = False
@@ -150,22 +152,22 @@ class SICKEntailmentEval(SICKRelatednessEval):
                     sick_data['y'].append(text[4])
         sick_data['y'] = [label2id[s] for s in sick_data['y']]
         return sick_data
-    
+
     def run(self, params, batcher):
         sick_embed = {'train':{}, 'dev':{}, 'test':{}}
-                      
-        for key in self.sick_data:  
+
+        for key in self.sick_data:
             logging.info('Computing embedding for {0}'.format(key))
             # Sort to reduce padding
             sorted_corpus = sorted(zip(self.sick_data[key]['X_A'],
                                        self.sick_data[key]['X_B'],
                                        self.sick_data[key]['y']),
                                    key=lambda z:(len(z[0]), len(z[1]), z[2]))
-            
+
             self.sick_data[key]['X_A'] = [x for (x,y,z) in sorted_corpus]
             self.sick_data[key]['X_B'] = [y for (x,y,z) in sorted_corpus]
             self.sick_data[key]['y'] = [z for (x,y,z) in sorted_corpus]
-            
+
             for txt_type in ['X_A', 'X_B']:
                 sick_embed[key][txt_type] = []
                 for ii in range(0, len(self.sick_data[key]['y']), params.batch_size):
@@ -174,34 +176,34 @@ class SICKEntailmentEval(SICKRelatednessEval):
                     sick_embed[key][txt_type].append(embeddings)
                 sick_embed[key][txt_type] = np.vstack(sick_embed[key][txt_type])
             logging.info('Computed {0} embeddings'.format(key))
-            
+
         # Train
         trainA = sick_embed['train']['X_A']
         trainB = sick_embed['train']['X_B']
         trainF = np.c_[np.abs(trainA - trainB), trainA * trainB]
         trainY = np.array(self.sick_data['train']['y'])
-        
+
         # Dev
         devA = sick_embed['dev']['X_A']
         devB = sick_embed['dev']['X_B']
         devF = np.c_[np.abs(devA - devB), devA * devB]
         devY = np.array(self.sick_data['dev']['y'])
-        
+
         # Test
         testA = sick_embed['test']['X_A']
         testB = sick_embed['test']['X_B']
         testF = np.c_[np.abs(testA - testB), testA * testB]
         testY = np.array(self.sick_data['test']['y'])
-        
+
         config_classifier = {'nclasses':3, 'seed':self.seed, 'usepytorch':params.usepytorch,\
                              'classifier':params.classifier, 'nhid': params.nhid}
         clf = SplitClassifier(X={'train':trainF, 'valid':devF, 'test':testF},
                               y={'train':trainY, 'valid':devY, 'test':testY},
                               config=config_classifier)
-        
+
         devacc, testacc = clf.run()
         logging.debug('\nDev acc : {0} Test acc : {1} for SICK entailment\n'.format(devacc, testacc))
         return {'devacc': devacc, 'acc': testacc, 'ndev': len(devA), 'ntest': len(testA)}
-        
-    
-    
+
+
+

--- a/senteval/snli.py
+++ b/senteval/snli.py
@@ -2,20 +2,22 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
 SNLI - Entailment
 '''
-from __future__ import division
+from __future__ import absolute_import, division, unicode_literals
 
 import codecs
 import os
+import io
 import logging
 import numpy as np
 
 from tools.validation import SplitClassifier
+
 
 class SNLIEval(object):
     def __init__(self, taskpath, seed=1111):
@@ -23,27 +25,27 @@ class SNLIEval(object):
         self.seed = seed
         train1 = self.loadFile(os.path.join(taskpath, 's1.train'))
         train2 = self.loadFile(os.path.join(taskpath, 's2.train'))
-        trainlabels = open(os.path.join(taskpath, 'labels.train')).read().splitlines()
+        trainlabels = io.open(os.path.join(taskpath, 'labels.train'), encoding='utf-8').read().splitlines()
 
         valid1 = self.loadFile(os.path.join(taskpath, 's1.dev'))
         valid2 = self.loadFile(os.path.join(taskpath, 's2.dev'))
-        validlabels = open(os.path.join(taskpath, 'labels.dev')).read().splitlines()
+        validlabels = io.open(os.path.join(taskpath, 'labels.dev'), encoding='utf-8').read().splitlines()
 
         test1 = self.loadFile(os.path.join(taskpath, 's1.test'))
         test2 = self.loadFile(os.path.join(taskpath, 's2.test'))
-        testlabels = open(os.path.join(taskpath, 'labels.test')).read().splitlines()
+        testlabels = io.open(os.path.join(taskpath, 'labels.test'), encoding='utf-8').read().splitlines()
 
         # sort data (by s2 first) to reduce padding
         sorted_train = sorted(zip(train2, train1, trainlabels), key=lambda z:(len(z[0]), len(z[1]), z[2]))
         train2, train1, trainlabels = map(list, zip(*sorted_train))
-        
+
         sorted_valid = sorted(zip(valid2, valid1, validlabels), key=lambda z:(len(z[0]), len(z[1]), z[2]))
         valid2, valid1, validlabels = map(list, zip(*sorted_valid))
-        
+
         sorted_test = sorted(zip(test2, test1, testlabels), key=lambda z:(len(z[0]), len(z[1]), z[2]))
         test2, test1, testlabels = map(list, zip(*sorted_test))
-        
-        
+
+
         self.samples = train1 + train2 + valid1 + valid2 + test1 + test2
         self.data = { \
             'train': (train1, train2, trainlabels), \

--- a/senteval/sst.py
+++ b/senteval/sst.py
@@ -2,18 +2,22 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
 SST - binary classification
 '''
 
+from __future__ import absolute_import, division, unicode_literals
+
 import os
+import io
 import logging
 import numpy as np
 
 from tools.validation import SplitClassifier
+
 
 class SSTBinaryEval(object):
     def __init__(self, task_path, seed=1111):
@@ -23,32 +27,31 @@ class SSTBinaryEval(object):
         dev = self.loadFile(os.path.join(task_path, 'sentiment-dev'))
         test = self.loadFile(os.path.join(task_path, 'sentiment-test'))
         self.sst_data = {'train':train, 'dev':dev, 'test':test}
-        
+
     def do_prepare(self, params, prepare):
         samples = self.sst_data['train']['X'] + self.sst_data['dev']['X'] + \
                   self.sst_data['test']['X']
         return prepare(params, samples)
-        
+
     def loadFile(self, fpath):
         sst_data = {'X':[], 'y':[]}
-        with open(fpath, 'rb') as f:
+        with io.open(fpath, 'r', encoding='utf-8') as f:
             for line in f:
                 sample = line.strip().split('\t')
                 sst_data['y'].append(int(sample[1]))
                 sst_data['X'].append(sample[0].split())
         return sst_data
-    
 
     def run(self, params, batcher):
         sst_embed = {'train':{}, 'dev':{}, 'test':{}}
-                      
-        for key in self.sst_data:  
+
+        for key in self.sst_data:
             logging.info('Computing embedding for {0}'.format(key))
             # Sort to reduce padding
             sorted_data = sorted(zip(self.sst_data[key]['X'], self.sst_data[key]['y']), key=lambda z:(len(z[0]), z[1]))
             self.sst_data[key]['X'], self.sst_data[key]['y'] = map(list, zip(*sorted_data))
-           
-            
+
+
             sst_embed[key]['X'] = []
             for ii in range(0, len(self.sst_data[key]['y']), params.batch_size):
                 batch = self.sst_data[key]['X'][ii:ii + params.batch_size]
@@ -63,7 +66,7 @@ class SSTBinaryEval(object):
         clf = SplitClassifier(X={'train':sst_embed['train']['X'], 'valid':sst_embed['dev']['X'], 'test':sst_embed['test']['X']},
                               y={'train':sst_embed['train']['y'], 'valid':sst_embed['dev']['y'], 'test':sst_embed['test']['y']},
                               config=config_classifier)
-        
+
         devacc, testacc = clf.run()
         logging.debug('\nDev acc : {0} Test acc : {1} for SST Binary classification\n'.format(devacc, testacc))
         return {'devacc': devacc, 'acc': testacc, 'ndev': len(sst_embed['dev']['X']), 'ntest': len(sst_embed['test']['X'])}

--- a/senteval/sts.py
+++ b/senteval/sts.py
@@ -2,14 +2,17 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 '''
 STS-{2012,2013,2014,2015,2016} (unsupervised) and STS-benchmark (supervised) tasks
 '''
 
+from __future__ import absolute_import, division, unicode_literals
+
 import os
+import io
 import numpy as np
 import logging
 
@@ -19,16 +22,15 @@ from utils import cosine
 from sick import SICKRelatednessEval
 
 
-
 class STSEval(object):
-        
+
     def loadFile(self, fpath):
         self.data = {}
         self.samples = []
-        
+
         for dataset in self.datasets:
-            sent1, sent2 = zip(*[l.split("\t") for l in open(fpath + '/STS.input.%s.txt' % dataset).read().splitlines()])
-            raw_scores = np.array([x for x in open(fpath + '/STS.gs.%s.txt' % dataset).read().splitlines()])
+            sent1, sent2 = zip(*[l.split("\t") for l in io.open(fpath + '/STS.input.%s.txt' % dataset, encoding='utf8').read().splitlines()])
+            raw_scores = np.array([x for x in io.open(fpath + '/STS.gs.%s.txt' % dataset, encoding='utf8').read().splitlines()])
             not_empty_idx = raw_scores != ''
 
             gs_scores = [float(x) for x in raw_scores[not_empty_idx]]
@@ -37,10 +39,9 @@ class STSEval(object):
             # sort data by length to minimize padding in batcher
             sorted_data = sorted(zip(sent1, sent2, gs_scores), key=lambda z:(len(z[0]), len(z[1]), z[2]))
             sent1, sent2, gs_scores = map(list, zip(*sorted_data))
-            
+
             self.data[dataset] = (sent1, sent2, gs_scores)
             self.samples += sent1 + sent2
-        
 
     def do_prepare(self, params, prepare):
         if 'similarity' in params:
@@ -48,7 +49,6 @@ class STSEval(object):
         else: # Default similarity is cosine
             self.similarity = lambda s1,s2: cosine(np.nan_to_num(s1), np.nan_to_num(s2))
         return prepare(params, self.samples)
-    
 
     def run(self, params, batcher):
         results = {}
@@ -58,7 +58,7 @@ class STSEval(object):
             for ii in range(0, len(gs_scores), params.batch_size):
                 batch1 = input1[ii:ii + params.batch_size]
                 batch2 = input2[ii:ii + params.batch_size]
-                
+
                 # we assume that the get_batch function already throws out the faulty ones
                 if len(batch1) == len(batch2) and len(batch1) > 0:
                     enc1 = batcher(params, batch1)
@@ -71,11 +71,11 @@ class STSEval(object):
             results[dataset] = {'pearson': pearsonr(sys_scores, gs_scores), 'spearman': spearmanr(sys_scores, gs_scores),\
                                 'nsamples': len(sys_scores)}
             logging.debug('%s : pearson = %.4f, spearman = %.4f' % (dataset, results[dataset]['pearson'][0], results[dataset]['spearman'][0]))
-            
+
         weights = [results[dset]['nsamples'] for dset in results.keys()]
         list_prs = np.array([results[dset]['pearson'][0] for dset in results.keys()])
         list_spr = np.array([results[dset]['spearman'][0] for dset in results.keys()])
-        
+
         avg_pearson = np.average(list_prs)
         avg_spearman = np.average(list_spr)
         wavg_pearson = np.average(list_prs, weights=weights)
@@ -88,43 +88,47 @@ class STSEval(object):
 
         return results
 
+
 class STS12Eval(STSEval):
     def __init__(self, taskpath, seed=1111):
         logging.debug('***** Transfer task : STS12 *****\n\n')
         self.seed = seed
         self.datasets = ['MSRpar', 'MSRvid', 'SMTeuroparl', 'surprise.OnWN', 'surprise.SMTnews']
-        self.loadFile(taskpath)    
-    
+        self.loadFile(taskpath)
+
+
 class STS13Eval(STSEval):
     def __init__(self, taskpath, seed=1111):
         logging.debug('***** Transfer task : STS13 (-SMT) *****\n\n') # SMT removed due to LICENSE issue
         self.seed = seed
         self.datasets = ['FNWN', 'headlines', 'OnWN']
         self.loadFile(taskpath)
-        
+
+
 class STS14Eval(STSEval):
     def __init__(self, taskpath, seed=1111):
         logging.debug('***** Transfer task : STS14 *****\n\n')
         self.seed = seed
         self.datasets = ['deft-forum', 'deft-news', 'headlines', 'images', 'OnWN', 'tweet-news']
         self.loadFile(taskpath)
-        
+
+
 class STS15Eval(STSEval):
     def __init__(self, taskpath, seed=1111):
         logging.debug('***** Transfer task : STS15 *****\n\n')
         self.seed = seed
         self.datasets = ['answers-forums', 'answers-students', 'belief', 'headlines', 'images']
         self.loadFile(taskpath)
-        
+
+
 class STS16Eval(STSEval):
     def __init__(self, taskpath, seed=1111):
         logging.debug('***** Transfer task : STS16 *****\n\n')
         self.seed = seed
         self.datasets = ['answer-answer', 'headlines', 'plagiarism', 'postediting', 'question-question']
-        self.loadFile(taskpath)        
-        
-        
-    
+        self.loadFile(taskpath)
+
+
 class STSBenchmarkEval(SICKRelatednessEval):
     def __init__(self, task_path, seed=1111):
         logging.debug('\n\n***** Transfer task : STSBenchmark*****\n\n')
@@ -133,15 +137,15 @@ class STSBenchmarkEval(SICKRelatednessEval):
         dev = self.loadFile(os.path.join(task_path, 'sts-dev.csv'))
         test = self.loadFile(os.path.join(task_path, 'sts-test.csv'))
         self.sick_data = {'train':train, 'dev':dev, 'test':test}
-        
+
     def loadFile(self, fpath):
         sick_data = {'X_A':[], 'X_B':[], 'y':[]}
-        with open(fpath, 'rb') as f:
+        with io.open(fpath, 'r', encoding='utf-8') as f:
             for line in f:
                 text = line.strip().split('\t')
                 sick_data['X_A'].append(text[5].split())
                 sick_data['X_B'].append(text[6].split())
                 sick_data['y'].append(text[4])
-        
+
         sick_data['y'] = [float(s) for s in sick_data['y']]
         return sick_data

--- a/senteval/tools/ranking.py
+++ b/senteval/tools/ranking.py
@@ -2,13 +2,13 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 """
 Image Annotation/Search for COCO with Pytorch
 """
-
+from __future__ import absolute_import, division, unicode_literals
 
 import logging
 import copy
@@ -32,7 +32,7 @@ class COCOProjNet(nn.Module):
         self.sentproj = nn.Sequential(
                         nn.Linear(self.sentdim, self.projdim),
                         )
-        
+
     def forward(self, img, sent, imgc, sentc):
         # imgc : (bsize, ncontrast, imgdim)
         # sentc : (bsize, ncontrast, sentdim)
@@ -42,7 +42,7 @@ class COCOProjNet(nn.Module):
         imgc = imgc.view(-1, self.imgdim)
         sent = sent.unsqueeze(1).expand_as(sentc).contiguous().view(-1, self.sentdim)
         sentc = sentc.view(-1, self.sentdim)
-        
+
         imgproj = self.imgproj(img)
         imgproj = imgproj / torch.sqrt(torch.pow(imgproj, 2).sum(1)).expand_as(imgproj)
         imgcproj = self.imgproj(imgc)
@@ -52,24 +52,25 @@ class COCOProjNet(nn.Module):
         sentcproj = self.sentproj(sentc)
         sentcproj = sentcproj / torch.sqrt(torch.pow(sentcproj, 2).sum(1)).expand_as(sentcproj)
         # (bsize*ncontrast, projdim)
-        
+
         anchor1 = torch.sum((imgproj*sentproj), 1).squeeze(1)
         anchor2 = torch.sum((sentproj*imgproj), 1).squeeze(1)
         img_sentc = torch.sum((imgproj*sentcproj), 1).squeeze(1)
         sent_imgc = torch.sum((sentproj*imgcproj), 1).squeeze(1)
-        
+
         # (bsize*ncontrast)
         return anchor1, anchor2, img_sentc, sent_imgc
-    
+
     def proj_sentence(self, sent):
         output = self.sentproj(sent)
         output = output / torch.sqrt(torch.pow(output, 2).sum(1)).expand_as(output)
         return output # (bsize, projdim)
-    
+
     def proj_image(self, img):
         output = self.imgproj(img)
         output = output / torch.sqrt(torch.pow(output, 2).sum(1)).expand_as(output)
         return output # (bsize, projdim)
+
 
 class PairwiseRankingLoss(nn.Module):
     """
@@ -86,8 +87,7 @@ class PairwiseRankingLoss(nn.Module):
         loss = cost_sent + cost_img
         return loss
 
-    
-    
+
 class ImageSentenceRankingPytorch(object):
     # Image Sentence Ranking on COCO with Pytorch
     def __init__(self, train, valid, test, config):
@@ -96,16 +96,16 @@ class ImageSentenceRankingPytorch(object):
         np.random.seed(self.seed)
         torch.manual_seed(self.seed)
         torch.cuda.manual_seed(self.seed)
-        
+
         self.train = train
         self.valid = valid
         self.test = test
-        
+
         self.imgdim = len(train['imgfeat'][0])
         self.sentdim = len(train['sentfeat'][0])
         self.projdim = config['projdim']
         self.margin = config['margin']
-        
+
         self.batch_size = 128
         self.ncontrast = 30
         self.maxepoch = 20
@@ -113,11 +113,11 @@ class ImageSentenceRankingPytorch(object):
 
         config_model = {'imgdim': self.imgdim,'sentdim': self.sentdim, 'projdim': self.projdim}
         self.model = COCOProjNet(config_model).cuda()
-        
+
         self.loss_fn = PairwiseRankingLoss(margin=self.margin).cuda()
-        
-        self.optimizer = optim.Adam(self.model.parameters())  
-    
+
+        self.optimizer = optim.Adam(self.model.parameters())
+
     def prepare_data(self, trainTxt, trainImg, devTxt, devImg, testTxt, testImg):
         trainTxt = torch.FloatTensor(trainTxt)
         trainImg = torch.FloatTensor(trainImg)
@@ -125,31 +125,31 @@ class ImageSentenceRankingPytorch(object):
         devImg = torch.FloatTensor(devImg).cuda()
         testTxt = torch.FloatTensor(testTxt).cuda()
         testImg = torch.FloatTensor(testImg).cuda()
-        
+
         return trainTxt, trainImg, devTxt, devImg, testTxt, testImg
-    
+
     def run(self):
         self.nepoch = 0
         bestdevscore = -1
         early_stop_count = 0
         r = np.arange(1,6)
         stop_train = False
-        
+
         # Preparing data
         logging.info('prepare data')
         trainTxt, trainImg, devTxt, devImg, testTxt, testImg = self.prepare_data(self.train['sentfeat'], self.train['imgfeat'], \
                                                        self.valid['sentfeat'], self.valid['imgfeat'], \
                                                        self.test['sentfeat'], self.test['imgfeat'])
-        
+
         # Training
         while not stop_train and self.nepoch<=self.maxepoch:
             logging.info('start epoch')
             self.trainepoch(trainTxt, trainImg, devTxt, devImg, nepoches=1)
             logging.info('Epoch {0} finished'.format(self.nepoch))
-            
-            
-            
-            
+
+
+
+
             results = {'i2t': {'r1':0, 'r5':0, 'r10':0, 'medr':0}, 't2i': {'r1':0, 'r5':0, 'r10':0, 'medr':0}, 'dev': bestdevscore}
             r1_i2t_test, r5_i2t_test, r10_i2t_test, medr_i2t_test, score = 0, 0, 0, 0, 0
             for i in range(5):
@@ -170,15 +170,15 @@ class ImageSentenceRankingPytorch(object):
                 results['t2i']['medr'] += medr_t2i / 5
                 logging.info("Text to Image: {0}, {1}, {2}, {3}".format(r1_t2i, r5_t2i, r10_t2i, medr_t2i))
                 score += (r1_i2t + r5_i2t + r10_i2t + r1_t2i + r5_t2i + r10_t2i) / 5
-                
+
             logging.info("Dev mean Text to Image: {0}, {1}, {2}, {3}".format(results['t2i']['r1'], results['t2i']['r5'],\
                                                                   results['t2i']['r10'], results['t2i']['medr']))
             logging.info("Dev mean Image to text: {0}, {1}, {2}, {3}".format(results['i2t']['r1'], results['i2t']['r5'],\
                                                                   results['i2t']['r10'], results['i2t']['medr']))
-        
-        
-       
-            
+
+
+
+
             # early stop on Pearson
             if score > bestdevscore:
                 bestdevscore = score
@@ -188,8 +188,7 @@ class ImageSentenceRankingPytorch(object):
                     stop_train = True
                 early_stop_count += 1
         self.model = bestmodel
-        
-        
+
         # Compute test for the 5 splits
         results = {'i2t': {'r1':0, 'r5':0, 'r10':0, 'medr':0}, 't2i': {'r1':0, 'r5':0, 'r10':0, 'medr':0}, 'dev': bestdevscore}
         r1_i2t_test, r5_i2t_test, r10_i2t_test, medr_i2t_test = 0, 0, 0, 0
@@ -208,7 +207,7 @@ class ImageSentenceRankingPytorch(object):
             results['t2i']['r5'] += r5_t2i / 5
             results['t2i']['r10'] += r10_t2i / 5
             results['t2i']['medr'] += medr_t2i / 5
-        
+
         return bestdevscore, results['i2t']['r1'], results['i2t']['r5'], results['i2t']['r10'], results['i2t']['medr'],\
                 results['t2i']['r1'], results['t2i']['r5'], results['t2i']['r10'], results['t2i']['medr']
 
@@ -225,7 +224,7 @@ class ImageSentenceRankingPytorch(object):
                     logging.info("Image to text: {0}, {1}, {2}, {3}".format(r1_i2t, r5_i2t, r10_i2t, medr_i2t))
                     # Compute test ranks txt2img
                     r1_t2i, r5_t2i, r10_t2i, medr_t2i = self.t2i(devImg, devTxt)
-                    logging.info("Text to Image: {0}, {1}, {2}, {3}".format(r1_t2i, r5_t2i, r10_t2i, medr_t2i))                    
+                    logging.info("Text to Image: {0}, {1}, {2}, {3}".format(r1_t2i, r5_t2i, r10_t2i, medr_t2i))
                 idx = torch.LongTensor(permutation[i:i + self.batch_size])
                 imgbatch = Variable(trainImg.index_select(0,idx)).cuda()
                 sentbatch = Variable(trainTxt.index_select(0,idx)).cuda()
@@ -237,7 +236,7 @@ class ImageSentenceRankingPytorch(object):
                 # Get indexes for contrastive images and sentences
                 imgcbatch = Variable(trainImg.index_select(0, idximgc)).view(-1, self.ncontrast, self.imgdim).cuda()
                 sentcbatch = Variable(trainTxt.index_select(0, idxsentc)).view(-1, self.ncontrast, self.sentdim).cuda()
-                
+
                 anchor1, anchor2, img_sentc, sent_imgc = self.model(imgbatch, sentbatch, imgcbatch, sentcbatch)
                 # loss
                 loss = self.loss_fn(anchor1, anchor2, img_sentc, sent_imgc)
@@ -248,7 +247,7 @@ class ImageSentenceRankingPytorch(object):
                 # Update parameters
                 self.optimizer.step()
         self.nepoch += nepoches
-        
+
     def t2i(self, images, captions):
         """
         Images: (5N, imgdim) matrix of images
@@ -261,8 +260,7 @@ class ImageSentenceRankingPytorch(object):
             sent_embed.append(self.model.proj_sentence(Variable(captions[i:i + self.batch_size], volatile=True)))
         img_embed = torch.cat(img_embed, 0).data
         sent_embed = torch.cat(sent_embed, 0).data
-        
-        
+
         npts = img_embed.size(0) / 5
         ims = img_embed.index_select(0, torch.cuda.LongTensor(range(0, len(img_embed), 5)))
 
@@ -285,7 +283,6 @@ class ImageSentenceRankingPytorch(object):
         r10 = 100.0 * len(np.where(ranks < 10)[0]) / len(ranks)
         medr = np.floor(np.median(ranks)) + 1
         return (r1, r5, r10, medr)
-    
 
     def i2t(self, images, captions):
         """
@@ -299,8 +296,8 @@ class ImageSentenceRankingPytorch(object):
             sent_embed.append(self.model.proj_sentence(Variable(captions[i:i + self.batch_size], volatile=True)))
         img_embed = torch.cat(img_embed, 0).data
         sent_embed = torch.cat(sent_embed, 0).data
-        
-        
+
+
         npts = img_embed.size(0) / 5
         # im = img_embed.index_select(torch.cuda.LongTensor(range(0, len(img_embed), 5)))
         index_list = []
@@ -324,10 +321,9 @@ class ImageSentenceRankingPytorch(object):
                     rank = tmp
             ranks[index] = rank
 
-
         # Compute metrics
         r1 = 100.0 * len(np.where(ranks < 1)[0]) / len(ranks)
         r5 = 100.0 * len(np.where(ranks < 5)[0]) / len(ranks)
         r10 = 100.0 * len(np.where(ranks < 10)[0]) / len(ranks)
         medr = np.floor(np.median(ranks)) + 1
-        return (r1, r5, r10, medr)    
+        return (r1, r5, r10, medr)

--- a/senteval/tools/validation.py
+++ b/senteval/tools/validation.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
 """
@@ -12,6 +12,7 @@ Validation and classification
 (train, dev, test) :  split classifier
 
 """
+from __future__ import absolute_import, division, unicode_literals
 
 import logging
 
@@ -22,7 +23,7 @@ assert(sklearn.__version__>="0.18.0"), "need to update sklearn to version >= 0.1
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import StratifiedKFold
 
-from classifier import LogReg, MLP
+from .classifier import LogReg, MLP
 
 
 # Pytorch version
@@ -44,7 +45,7 @@ class InnerKFoldClassifier(object):
         self.modelname = 'sklearn-LogReg' if not config['usepytorch'] else 'pytorch-' + config['classifier']
 
         self.k = 5 if 'kfold' not in config else config['kfold']
-        
+
     def run(self):
         logging.info('Training {0} with (inner) {1}-fold cross-validation'.format(self.modelname, self.k))
 
@@ -86,9 +87,9 @@ class InnerKFoldClassifier(object):
             else:
                 clf = LogisticRegression(C=optreg, random_state=self.seed)
                 clf.fit(X_train, y_train)
-                
+
             self.testresults.append(round(100*clf.score(X_test, y_test),2))
-            
+
         devaccuracy = round(np.mean(self.devresults), 2) # TODO
         testaccuracy = round(np.mean(self.testresults), 2)
         return devaccuracy, testaccuracy
@@ -139,13 +140,13 @@ class KFoldClassifier(object):
                 scanscores.append(score)
             # Append mean score
             scores.append(round(100*np.mean(scanscores),2))
-        
+
         # evaluation
         logging.info([('reg:'+str(regs[idx]), scores[idx]) for idx in range(len(scores))])
         optreg = regs[np.argmax(scores)]
         devaccuracy = np.max(scores)
         logging.info('Cross-validation : best param found is reg = {0} with score {1}'.format(optreg, devaccuracy))
-        
+
         logging.info('Evaluating...')
         if self.usepytorch:
             if self.classifier == 'LogReg':
@@ -157,13 +158,13 @@ class KFoldClassifier(object):
             clf = LogisticRegression(C=optreg, random_state=self.seed)
             clf.fit(self.train['X'], self.train['y'])
         yhat = clf.predict(self.test['X'])
-        
+
         testaccuracy = clf.score(self.test['X'], self.test['y'])
         testaccuracy = round(100*testaccuracy, 2)
-        
+
         return devaccuracy, testaccuracy, yhat
-        
-    
+
+
 class SplitClassifier(object):
     """
     (train, valid, test) split classifier.
@@ -182,7 +183,7 @@ class SplitClassifier(object):
         self.nepoches = None if 'nepoches' not in config else config['nepoches']
         self.maxepoch = None if 'maxepoch' not in config else config['maxepoch']
         self.noreg = False if 'noreg' not in config else config['noreg']
-        
+
     def run(self):
         logging.info('Training {0} with standard validation..'.format(self.modelname))
         regs = [10**t for t in range(-5,-1)] if self.usepytorch else [2**t for t in range(-2,4,1)]
@@ -207,7 +208,7 @@ class SplitClassifier(object):
         logging.info([('reg:'+str(regs[idx]), scores[idx]) for idx in range(len(scores))])
         optreg = regs[np.argmax(scores)]
         devaccuracy = np.max(scores)
-        logging.info('Validation : best param found is reg = {0} with score {1}'.format(optreg, devaccuracy))               
+        logging.info('Validation : best param found is reg = {0} with score {1}'.format(optreg, devaccuracy))
         clf = LogisticRegression(C=optreg, random_state=self.seed)
         logging.info('Evaluating...')
         if self.usepytorch:
@@ -224,9 +225,8 @@ class SplitClassifier(object):
         else:
             clf = LogisticRegression(C=optreg, random_state=self.seed)
             clf.fit(self.X['train'], self.y['train'])
-            
+
         testaccuracy = clf.score(self.X['test'], self.y['test'])
         testaccuracy = round(100*testaccuracy, 2)
         return devaccuracy, testaccuracy
-    
-    
+

--- a/senteval/utils.py
+++ b/senteval/utils.py
@@ -2,10 +2,13 @@
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 #
 
+from __future__ import absolute_import, division, unicode_literals
+
 import numpy as np
+
 
 def create_dictionary(sentences):
     words = {}
@@ -25,8 +28,9 @@ def create_dictionary(sentences):
     for i, (w, _) in enumerate(sorted_words):
         id2word.append(w)
         word2id[w] = i
-    
+
     return id2word, word2id
+
 
 def cosine(u, v):
     return np.dot(u, v) / (np.linalg.norm(u) * np.linalg.norm(v))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+import io
+from setuptools import setup, find_packages
+
+with io.open('./README.md', encoding='utf-8') as f:
+    readme = f.read()
+
+
+
+setup(
+    name='SentEval',
+    version='0.1.0',
+    url='https://github.com/facebookresearch/SentEval',
+    packages=find_packages(exclude=['examples']),
+    license='Attribution-NonCommercial 4.0 International',
+    long_description=readme,
+)


### PR DESCRIPTION
Fixes #4 

- Added a `setup.py` file to allow for installation through pip.
- Added `__future__` imports
- Replaced `open` with compabible `io.open`
- Added checks for `torch.cuda.is_available()`
- Moved package contents into folder `senteval` (This is required for pip installation)
- Fixed some whitespace inconsistencies

Tested on `bow.py` with Python 3.5 and 2.7. Exactly the same numbers roll out.

You can test it using `pip install git+https://github.com/tscheepers/SentEval.git@setuppy`