### PR TITLE
Fixed imports when using the pip package

### DIFF
--- a/examples/bow.py
+++ b/examples/bow.py
@@ -16,13 +16,13 @@ import data
 import torch
 
 # Set PATHs
-PATH_TO_SENTEVAL = '../senteval'
+PATH_TO_SENTEVAL = '../'
 PATH_TO_DATA = '../data/senteval_data'
 PATH_TO_GLOVE = 'glove/glove.840B.300d.txt'
 
 # import SentEval
 sys.path.insert(0, PATH_TO_SENTEVAL)
-import senteval
+from senteval.senteval import SentEval
 
 
 """
@@ -55,7 +55,7 @@ def batcher(params, batch):
             if word in params.word_vec:
                 sentvec.append(params.word_vec[word])
         if not sentvec:
-            vec = np.zeros(len(params.word_vec.values()[0]))
+            vec = np.zeros(len(list(params.word_vec.values())[0]))
             sentvec.append(vec)
         sentvec = np.mean(sentvec, 0)
         embeddings.append(sentvec)
@@ -72,7 +72,7 @@ params_senteval = dotdict(params_senteval)
 logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
 
 if __name__ == "__main__":
-    se = senteval.SentEval(params_senteval, batcher, prepare)
+    se = SentEval(params_senteval, batcher, prepare)
     transfer_tasks = ['MR', 'CR', 'MPQA', 'SUBJ', 'SST', 'TREC',
                       'MRPC', 'SICKEntailment', 'SICKRelatedness',
                       'STSBenchmark', 'STS14']

--- a/examples/bow.py
+++ b/examples/bow.py
@@ -22,7 +22,7 @@ PATH_TO_GLOVE = 'glove/glove.840B.300d.txt'
 
 # import SentEval
 sys.path.insert(0, PATH_TO_SENTEVAL)
-from senteval.senteval import SentEval
+import senteval
 
 
 """
@@ -55,7 +55,7 @@ def batcher(params, batch):
             if word in params.word_vec:
                 sentvec.append(params.word_vec[word])
         if not sentvec:
-            vec = np.zeros(len(list(params.word_vec.values())[0]))
+            vec = np.zeros(len(next(params.word_vec.values())))
             sentvec.append(vec)
         sentvec = np.mean(sentvec, 0)
         embeddings.append(sentvec)
@@ -72,7 +72,7 @@ params_senteval = dotdict(params_senteval)
 logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
 
 if __name__ == "__main__":
-    se = SentEval(params_senteval, batcher, prepare)
+    se = senteval.SentEval(params_senteval, batcher, prepare)
     transfer_tasks = ['MR', 'CR', 'MPQA', 'SUBJ', 'SST', 'TREC',
                       'MRPC', 'SICKEntailment', 'SICKRelatedness',
                       'STSBenchmark', 'STS14']

--- a/examples/infersent.py
+++ b/examples/infersent.py
@@ -25,7 +25,7 @@ assert os.path.isfile(MODEL_PATH) and os.path.isfile(GLOVE_PATH), \
 
 # import senteval
 sys.path.insert(0, PATH_SENTEVAL)
-from senteval.senteval import SentEval
+import senteval
 
 
 def prepare(params, samples):
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     params_senteval.infersent = torch.load(MODEL_PATH)
     params_senteval.infersent.set_glove_path(GLOVE_PATH)
 
-    se = SentEval(params_senteval, batcher, prepare)
+    se = senteval.SentEval(params_senteval, batcher, prepare)
     results_transfer = se.eval(transfer_tasks)
 
     print(results_transfer)

--- a/examples/infersent.py
+++ b/examples/infersent.py
@@ -16,7 +16,7 @@ import logging
 
 # Set PATHs
 GLOVE_PATH = 'glove/glove.840B.300d.txt'
-PATH_SENTEVAL = '../senteval'
+PATH_SENTEVAL = '../'
 PATH_TO_DATA = '../data/senteval_data/'
 MODEL_PATH = 'infersent.allnli.pickle'
 
@@ -25,7 +25,7 @@ assert os.path.isfile(MODEL_PATH) and os.path.isfile(GLOVE_PATH), \
 
 # import senteval
 sys.path.insert(0, PATH_SENTEVAL)
-import senteval
+from senteval.senteval import SentEval
 
 
 def prepare(params, samples):
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     params_senteval.infersent = torch.load(MODEL_PATH)
     params_senteval.infersent.set_glove_path(GLOVE_PATH)
 
-    se = senteval.SentEval(params_senteval, batcher, prepare)
+    se = SentEval(params_senteval, batcher, prepare)
     results_transfer = se.eval(transfer_tasks)
 
     print(results_transfer)

--- a/examples/skipthought.py
+++ b/examples/skipthought.py
@@ -26,7 +26,7 @@ assert PATH_TO_SKIPTHOUGHT != '', 'Download skipthought and set correct PATH'
 sys.path.insert(0, PATH_TO_SKIPTHOUGHT)
 sys.path.insert(0, PATH_TO_SENTEVAL)
 import skipthoughts
-import senteval
+from senteval.senteval import SentEval
 
 
 def prepare(params, samples):
@@ -51,6 +51,6 @@ logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
 
 if __name__ == "__main__":
     params_senteval.encoder = skipthoughts.load_model()
-    se = senteval.SentEval(params_senteval, batcher, prepare)
+    se = SentEval(params_senteval, batcher, prepare)
     se.eval(['MR', 'CR', 'SUBJ', 'MPQA', 'SST', 'TREC', 'SICKRelatedness',
              'SICKEntailment', 'MRPC', 'STS14', 'ImageAnnotation'])

--- a/examples/skipthought.py
+++ b/examples/skipthought.py
@@ -26,7 +26,7 @@ assert PATH_TO_SKIPTHOUGHT != '', 'Download skipthought and set correct PATH'
 sys.path.insert(0, PATH_TO_SKIPTHOUGHT)
 sys.path.insert(0, PATH_TO_SENTEVAL)
 import skipthoughts
-from senteval.senteval import SentEval
+import senteval
 
 
 def prepare(params, samples):
@@ -51,6 +51,6 @@ logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
 
 if __name__ == "__main__":
     params_senteval.encoder = skipthoughts.load_model()
-    se = SentEval(params_senteval, batcher, prepare)
+    se = senteval.SentEval(params_senteval, batcher, prepare)
     se.eval(['MR', 'CR', 'SUBJ', 'MPQA', 'SST', 'TREC', 'SICKRelatedness',
              'SICKEntailment', 'MRPC', 'STS14', 'ImageAnnotation'])

--- a/senteval/__init__.py
+++ b/senteval/__init__.py
@@ -1,3 +1,0 @@
-from __future__ import absolute_import
-
-from .senteval import SentEval

--- a/senteval/__init__.py
+++ b/senteval/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from __future__ import absolute_import
+
+from senteval.senteval import SentEval

--- a/senteval/binary.py
+++ b/senteval/binary.py
@@ -15,7 +15,7 @@ import os
 import numpy as np
 import logging
 
-from tools.validation import InnerKFoldClassifier
+from senteval.tools.validation import InnerKFoldClassifier
 
 
 class BinaryClassifierEval(object):

--- a/senteval/mrpc.py
+++ b/senteval/mrpc.py
@@ -15,7 +15,7 @@ import logging
 import numpy as np
 import io
 
-from tools.validation import KFoldClassifier
+from senteval.tools.validation import KFoldClassifier
 
 from sklearn.metrics import f1_score
 

--- a/senteval/rank.py
+++ b/senteval/rank.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     import pickle
 
-from tools.ranking import ImageSentenceRankingPytorch
+from senteval.tools.ranking import ImageSentenceRankingPytorch
 
 
 class ImageCaptionRetrievalEval(object):

--- a/senteval/senteval.py
+++ b/senteval/senteval.py
@@ -12,15 +12,15 @@ Generic sentence evaluation scripts wrapper
 '''
 from __future__ import absolute_import, division, unicode_literals
 
-from binary import CREval, MREval, MPQAEval, SUBJEval
-from snli import SNLIEval
-from trec import TRECEval
-from sick import SICKRelatednessEval, SICKEntailmentEval
-from mrpc import MRPCEval
-from sts import STS12Eval, STS13Eval, STS14Eval, STS15Eval, STS16Eval, \
+from senteval.binary import CREval, MREval, MPQAEval, SUBJEval
+from senteval.snli import SNLIEval
+from senteval.trec import TRECEval
+from senteval.sick import SICKRelatednessEval, SICKEntailmentEval
+from senteval.mrpc import MRPCEval
+from senteval.sts import STS12Eval, STS13Eval, STS14Eval, STS15Eval, STS16Eval, \
     STSBenchmarkEval
-from sst import SSTBinaryEval
-from rank import ImageCaptionRetrievalEval
+from senteval.sst import SSTBinaryEval
+from senteval.rank import ImageCaptionRetrievalEval
 
 
 class SentEval(object):

--- a/senteval/sick.py
+++ b/senteval/sick.py
@@ -18,8 +18,8 @@ import numpy as np
 from sklearn.metrics import mean_squared_error
 from scipy.stats import pearsonr, spearmanr
 
-from tools.relatedness import RelatednessPytorch
-from tools.validation import SplitClassifier
+from senteval.tools.relatedness import RelatednessPytorch
+from senteval.tools.validation import SplitClassifier
 
 
 class SICKRelatednessEval(object):

--- a/senteval/snli.py
+++ b/senteval/snli.py
@@ -16,7 +16,7 @@ import io
 import logging
 import numpy as np
 
-from tools.validation import SplitClassifier
+from senteval.tools.validation import SplitClassifier
 
 
 class SNLIEval(object):

--- a/senteval/sst.py
+++ b/senteval/sst.py
@@ -16,7 +16,7 @@ import io
 import logging
 import numpy as np
 
-from tools.validation import SplitClassifier
+from senteval.tools.validation import SplitClassifier
 
 
 class SSTBinaryEval(object):

--- a/senteval/sts.py
+++ b/senteval/sts.py
@@ -19,8 +19,8 @@ import logging
 
 from scipy.stats import spearmanr, pearsonr
 
-from utils import cosine
-from sick import SICKRelatednessEval
+from senteval.utils import cosine
+from senteval.sick import SICKRelatednessEval
 
 
 class STSEval(object):

--- a/senteval/tools/validation.py
+++ b/senteval/tools/validation.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 import logging
 import numpy as np
-from .classifier import LogReg, MLP
+from senteval.tools.classifier import LogReg, MLP
 
 import sklearn
 assert(sklearn.__version__ >= "0.18.0"), \

--- a/senteval/trec.py
+++ b/senteval/trec.py
@@ -16,7 +16,7 @@ import io
 import logging
 import numpy as np
 
-from tools.validation import KFoldClassifier
+from senteval.tools.validation import KFoldClassifier
 
 
 class TRECEval(object):


### PR DESCRIPTION
Fixed pip imports as described in https://github.com/facebookresearch/SentEval/pull/5#issuecomment-316371715

This importing is slightly more complicated than you would expect: https://stackoverflow.com/questions/16981921/relative-imports-in-python-3

Now you can run `bow.py` from the repository itself or run `bow.py` using an installed pip package on both Python 2.7 as well as Python 3.5.

Also fixed small `dict_values` Python 3.x incompatibility, `TypeError: 'dict_values' object does not support indexing`