### PR TITLE
Update get_transfer_data.bash

### DIFF
--- a/data/downstream/get_transfer_data.bash
+++ b/data/downstream/get_transfer_data.bash
@@ -88,7 +88,7 @@ do
     for sts_task in ${STS_tasks[$task]}
     do
         fname=STS.input.$sts_task.txt
-        task_path=$data_path/STS/$task-en-test/
+        task_path=$data_path/STS/$task-en-test
 
         if [ "$task" = "STS16" ] ; then
             echo 'Handling STS2016'


### PR DESCRIPTION
removed extra '/' because while `mv $task_path/STS2016.input.$sts_task.txt $task_path/$fname`, path becomes 
`$task_path//STS2016 ...` which fails script.