### PR TITLE
Remove Redundant Logistic Regression Instance Creation

### DIFF
--- a/senteval/tools/validation.py
+++ b/senteval/tools/validation.py
@@ -227,7 +227,6 @@ class SplitClassifier(object):
         devaccuracy = np.max(scores)
         logging.info('Validation : best param found is reg = {0} with score \
             {1}'.format(optreg, devaccuracy))
-        clf = LogisticRegression(C=optreg, random_state=self.seed)
         logging.info('Evaluating...')
         if self.usepytorch:
             clf = MLP(self.classifier_config, inputdim=self.featdim,


### PR DESCRIPTION
clf object is created in line 232 or line 237. Therefore, creation of clf object above if statement is redundant.