### PR TITLE
Change URL for trained fastText model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To download state-of-the-art fastText embeddings:
 
 ```bash
 curl -Lo glove.840B.300d.zip http://nlp.stanford.edu/data/glove.840B.300d.zip
-curl -Lo crawl-300d-2M.vec.zip https://s3-us-west-1.amazonaws.com/fasttext-vectors/crawl-300d-2M.vec.zip
+curl -Lo crawl-300d-2M.vec.zip https://dl.fbaipublicfiles.com/fasttext/vectors-english/crawl-300d-2M.vec.zip
 ```
 
 To reproduce the results for bag-of-vectors, run (in examples/):  


### PR DESCRIPTION
Previous URL seemed dead, at least to the public.