### PR TITLE
Fixed examples/gensen.py

### DIFF
--- a/examples/gensen.py
+++ b/examples/gensen.py
@@ -31,8 +31,8 @@ def prepare(params, samples):
 
 def batcher(params, batch):
     batch = [' '.join(sent) if sent != [] else '.' for sent in batch]
-    _, reps_h_t = gensen.get_representation(
-        sentences, pool='last', return_numpy=True, tokenize=True
+    _, reps_h_t = params['gensen'].get_representation(
+        batch, pool='last', return_numpy=True, tokenize=True
     )
     embeddings = reps_h_t
     return embeddings
@@ -49,9 +49,6 @@ gensen_2 = GenSenSingle(
     pretrained_emb='../data/embedding/glove.840B.300d.h5'
 )
 gensen_encoder = GenSen(gensen_1, gensen_2)
-reps_h, reps_h_t = gensen.get_representation(
-    sentences, pool='last', return_numpy=True, tokenize=True
-)
 
 # Set params for SentEval
 params_senteval = {'task_path': PATH_TO_DATA, 'usepytorch': True, 'kfold': 5}


### PR DESCRIPTION
```examples/gensen.py,  batcher``` func has undefined ```gensen``` and ```sentences``` variables. Now they are replaced with their appropriate var names.