### PR TITLE
Update utils.py to be compatible with 3.9 and on

### DIFF
--- a/senteval/utils.py
+++ b/senteval/utils.py
@@ -86,7 +86,7 @@ def get_optimizer(s):
         raise Exception('Unknown optimization method: "%s"' % method)
 
     # check that we give good parameters to the optimizer
-    expected_args = inspect.getargspec(optim_fn.__init__)[0]
+    expected_args = inspect.getfullargspec(optim_fn.__init__)[0]
     assert expected_args[:2] == ['self', 'params']
     if not all(k in expected_args[2:] for k in optim_params.keys()):
         raise Exception('Unexpected parameters: expected "%s", got "%s"' % (


### PR DESCRIPTION
`inspect.getargspec` has been deprecated since Python 3.0 ([docs](https://docs.python.org/3/library/inspect.html#inspect.getargspec)) and using it can result in errors with 3.9. Running the evaluation with Python 3.9 and up fails with:

```
  File "/home/stefan/.local/lib/python3.9/site-packages/senteval/utils.py", line 89, in get_optimizer
    expected_args = inspect.getargspec(optim_fn.__init__)[0]
  File "/usr/lib/python3.9/inspect.py", line 1122, in getargspec
    raise ValueError("Function has keyword-only parameters or annotations"
ValueError: Function has keyword-only parameters or annotations, use inspect.signature() API which can support them
```

This PR replaces `inspect.getargspec` with the drop-in replacement `inspect.getfullargspec`, as suggested in the docs.